### PR TITLE
Removed unnused dependency (LGPL license might be offputting to some)

### DIFF
--- a/sdl3.cabal
+++ b/sdl3.cabal
@@ -1235,7 +1235,6 @@ executable binding-checker
     directory >=1.3 && <1.4,
     filepath >=1.4 && <1.6,
     process >=1.6 && <1.7,
-    regex-posix >=0.96 && <0.97,
 
   hs-source-dirs: test
   default-language: Haskell2010


### PR DESCRIPTION
The regex-posix dependency didn't appear to be necessary and a library it depends on is LGPL-licensed which might put some people off when using this project. Since the dependency doesn't appear to be used I removed it.